### PR TITLE
remove margin-top assigned to the quick-form

### DIFF
--- a/xadmin/static/xadmin/js/xadmin.plugin.quick-form.js
+++ b/xadmin/static/xadmin/js/xadmin.plugin.quick-form.js
@@ -188,12 +188,7 @@
         })
         this.modal = modal
       }
-      this.modal.modal().css(
-          {
-              'margin-top': function () {
-                  return window.pageYOffset;
-              }
-          });
+      this.modal.modal();
 
       return false
     }


### PR DESCRIPTION
quick form 使用的Bootstrap的model class，使用的是fixed的定位，不需要根据页面滚动位置来调节弹出框的定位。
