### PR TITLE
Fixed reverse many 2 many lookup giving FieldDoesNotExist error.

### DIFF
--- a/xadmin/plugins/relate.py
+++ b/xadmin/plugins/relate.py
@@ -93,7 +93,7 @@ class RelateObject(object):
         self.value = value
 
         parts = lookup.split(LOOKUP_SEP)
-        field = self.opts.get_field(parts[0])
+        field = self.opts.get_field_by_name(parts[0])[0]
 
         if not hasattr(field, 'rel') and not isinstance(field, RelatedObject):
             raise Exception(u'Relate Lookup field must a related field')


### PR DESCRIPTION
The current implementation only works one way (you can do a _rel_ search only from the model that has the related field defined). This way you can filter from both models.

``` python

class A(models.Model):
    pass # your fields here

class B(models.Model):
    a = models.ManyToManyField(A)

```

So you can filter by 

`/app/a/?_rel_b__id__exact=1`

and

`/app/b/?_rel_a__id__exact=1`
