### PR TITLE
Fixed user permission check in inline model, where only people who have ...

### DIFF
--- a/xadmin/templates/xadmin/edit_inline/base.html
+++ b/xadmin/templates/xadmin/edit_inline/base.html
@@ -6,7 +6,9 @@
 
 {% block box_title %}
   {% if not formset.formset.detail_page %}
+  {% if has_add_permission %}
   <a class="add-row" id="{{ prefix }}-add-row" href="javascript:void(0)"><i class="icon fa fa-plus"></i></a>
+  {% endif %}
   {% endif %}
   {{ formset.opts.verbose_name_plural|title }}
 {% endblock box_title %}


### PR DESCRIPTION
...'add_permission' perm, should have '+' icon to add new elements. It's fix for #142 from main django-xadmin project.
