### PR TITLE
Use methode(self, obj) in InlineModelAdmin for use in readonly_fields.

### DIFF
--- a/xadmin/plugins/inline.py
+++ b/xadmin/plugins/inline.py
@@ -226,6 +226,9 @@ class InlineModelAdmin(ModelFormAdminView):
                         elif inspect.ismethod(getattr(inst, readonly_field, None)):
                             value = getattr(inst, readonly_field)()
                             label = getattr(getattr(inst, readonly_field), 'short_description', readonly_field)
+                        elif inspect.ismethod(getattr(self, readonly_field, None)):
+                            value = getattr(self, readonly_field)(inst)
+                            label = getattr(getattr(self, readonly_field), 'short_description', readonly_field)
                         if value:
                             form.readonly_fields.append({'label': label, 'contents': value})
         return instance


### PR DESCRIPTION
Hi.
This this support for method for readonly_fields in InlineModelAdmin.
Exemple : 

```
class WishInline(object):

  def email(self, obj):
      return obj.individu.personal_email  
  readonly_fields = ['email']
```

see https://docs.djangoproject.com/en/1.6/ref/contrib/admin/#django.contrib.admin.ModelAdmin.readonly_fields

"""
A read-only field can not only display data from a model’s field, it can also display the output of a model’s method or a method of the ModelAdmin class itself.
"""

Thx for your great application 
