### PR TITLE
sitemenu: fix adding menu without submenu

### DIFF
--- a/xadmin/templates/xadmin/includes/sitemenu_default.html
+++ b/xadmin/templates/xadmin/includes/sitemenu_default.html
@@ -7,7 +7,7 @@
       <a href="{% url 'xadmin:index' %}"><i class="fa-fw fa fa-home"></i> {% trans 'Home' %}</a>
     </li>
     {% for item in nav_menu %}
-      <li class="nav-header {% if item.selected %} active{% endif %}">
+      <li class="{% if item.menus %}nav-header{% endif %} {% if item.selected %} active{% endif %}">
         {% if item.url %}<a href="{{ item.url }}" class="section">{% endif %}
         {% if item.icon %}<i class="fa-fw {{item.icon}}"></i>{% endif %}{{ item.title }}
         {% if item.url %}</a>{% endif %}

--- a/xadmin/views/base.py
+++ b/xadmin/views/base.py
@@ -407,7 +407,6 @@ class CommAdminView(BaseAdminView):
                 return item
 
             nav_menu = [filter_item(item) for item in menus if check_menu_permission(item)]
-            nav_menu = filter(lambda i: bool(i['menus']), nav_menu)
 
             if not settings.DEBUG:
                 self.request.session['nav_menu'] = json.dumps(nav_menu)


### PR DESCRIPTION
The filter will throw an exception if 'menus' not specified in a custom site menu returned by get_site_menu.
Also fix style on menu item which does not have submenu.
