### PR TITLE
fix nav_menu

### DIFF
--- a/xadmin/views/base.py
+++ b/xadmin/views/base.py
@@ -403,11 +403,16 @@ class CommAdminView(BaseAdminView):
 
             def filter_item(item):
                 if 'menus' in item:
+                    before_filter_length = len(item['menu'])
                     item['menus'] = [filter_item(
                         i) for i in item['menus'] if check_menu_permission(i)]
+                    after_filter_length = len(item['menus'])
+                    if after_filter_length == 0 and before_filter_length > 0:
+                        return None
                 return item
 
             nav_menu = [filter_item(item) for item in menus if check_menu_permission(item)]
+            nav_menu = filter(lambda x:x, nav_menu)
 
             if not settings.DEBUG:
                 self.request.session['nav_menu'] = json.dumps(nav_menu)


### PR DESCRIPTION
in commit 1d55f6089f4640ddcadd3f24f42482665645d36a, it remove the filter
to avoid an exception when adding custom site menu without submenu. But
it result in showing a raw menu title when the menu has submenu and user
has no permission to all the submenu items.
