### PR TITLE
fix non-field-error duplicate show in model_form

### DIFF
--- a/xadmin/templates/xadmin/views/model_form.html
+++ b/xadmin/templates/xadmin/views/model_form.html
@@ -19,7 +19,6 @@
         <button type="button" class="close" data-dismiss="alert">&times;</button>
       {% blocktrans count counter=errors|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktrans %}
       </div>
-      {{ form.non_field_errors }}
   {% endif %}
 
   {% view_block 'before_fieldsets' %}


### PR DESCRIPTION
The crispy form done the same thing: https://github.com/maraujop/django-crispy-forms/blob/dev/crispy_forms/templates/bootstrap3/errors.html#L5
