### PR TITLE
Allow setting query string and form value to 0.

### DIFF
--- a/xadmin/views/base.py
+++ b/xadmin/views/base.py
@@ -159,7 +159,8 @@ class BaseAdminObject(object):
             p = filte_dict(p, lambda key, value: not key.startswith(r) )
 
         for k, v in new_params.items():
-            if v: p[k] = v
+            if v is not None:
+                p[k] = v
 
         return '?%s' % urlencode(p)
 
@@ -174,10 +175,11 @@ class BaseAdminObject(object):
             p = filte_dict(p, lambda key, value: not key.startswith(r) )
 
         for k, v in new_params.items():
-            if v: p[k] = v
+            if v is not None:
+                p[k] = v
 
         return mark_safe(''.join(
-            '<input type="hidden" name="%s" value="%s"/>' % (k, v) for k, v in p.items() if v))
+            '<input type="hidden" name="%s" value="%s"/>' % (k, v) for k, v in p.items() if v is not None))
 
     def render_response(self, content, response_type='json'):
         if response_type == 'json':


### PR DESCRIPTION
Commit c6bc3981 有个bug: 通过 `if v` 而不是 `if v is not None` 来判断value是否合法, 从而导致不能将 qs 设为 0
这个 bug 会导致pagination的第一个链接是错误的(xxx/?p=0)
