### PR TITLE
让 过滤器  仅显示 verbose_name ,不在现实 原始模型名

### DIFF
--- a/xadmin/plugins/filters.py
+++ b/xadmin/plugins/filters.py
@@ -120,8 +120,8 @@ class FilterPlugin(BaseAdminPlugin):
 
                     if len(field_parts)>1:
                         # Add related model name to title
-                        spec.title = "%s %s"%(field_parts[-2].name,spec.title)
-
+                        #spec.title = "%s %s"%(field_parts[-2].name,spec.title)
+                        spec.title = "%s"%(spec.title)
                     # Check if we need to use distinct()
                     use_distinct = (use_distinct or
                                     lookup_needs_distinct(self.opts, field_path))


### PR DESCRIPTION
当 过滤器 的对象 有引用关系 时候会显示原来的model名.
所以隐藏了. 不知道影响其它代码不.