### PR TITLE
修正 django1.8 分支下一处 py3 的兼容性修改导致的 bug。

### DIFF
--- a/xadmin/plugins/auth.py
+++ b/xadmin/plugins/auth.py
@@ -196,7 +196,7 @@ class ChangePasswordView(ModelAdminView):
         self.form.helper = helper
 
         context.update({
-            'title': _('Change password: %s') % escape(six.u(self.obj)),
+            'title': _('Change password: %s') % escape(six.text_type(self.obj)),
             'form': self.form,
             'has_delete_permission': False,
             'has_change_permission': True,


### PR DESCRIPTION
我误以为 six.u 就是 py2 里的 unicode ，导致 py2 下出现:  AttributeError: 'User' object has no attribute 'replace'