### PR TITLE
fix bug that can't get correct related model when related model is set to be list_filter

### DIFF
--- a/xadmin/util.py
+++ b/xadmin/util.py
@@ -355,7 +355,9 @@ class NotRelationField(Exception):
     pass
 
 def get_model_from_relation(field):
-    if is_related_field(field):
+    if field.related_model:
+        return field.related_model
+    elif is_related_field(field):
         return field.model
     elif getattr(field, 'rel'):  # or isinstance?
         return field.rel.to


### PR DESCRIPTION
fix bug that can't get correct related model when related model is set to be list_filter.