### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ django>=2
 django-crispy-forms>=1.6.0
 django-import-export>=0.5.1
 django-reversion>=2.0.0
-django-formtools==2.0
+django-formtools==2.1
 future==0.15.2
 httplib2==0.9.2
 six==1.10.0


### PR DESCRIPTION
fix requirements.txt django-formtools==2.1, error: ImportError: No module named 'django.contrib.formtools'