### PR TITLE
修复获取单个记录时引发select all的问题

### DIFF
--- a/xadmin/views/base.py
+++ b/xadmin/views/base.py
@@ -526,11 +526,10 @@ class ModelAdminView(CommAdminView):
         Get model object instance by object_id, used for change admin view
         """
         # first get base admin view property queryset, return default model queryset
-        queryset = self.queryset()
-        model = queryset.model
+        model = self.model
         try:
             object_id = model._meta.pk.to_python(object_id)
-            return queryset.get(pk=object_id)
+            return model.objects.get(pk=object_id)
         except (model.DoesNotExist, ValidationError):
             return None
 


### PR DESCRIPTION
支持国产，讨论问题也不用再去找翻译了哈哈哈。

这个问题是这样的，我用的 `list_editable` 功能，能在表格内直接对记录修改。但是我发现会引起select all的，然后再select pk，两次数据库查询，显然第一次的查询是多余的，性能还很差。

这个RP解决了这个问题。