### PR TITLE
修复列表页重复查询的问题

### DIFF
--- a/xadmin/views/list.py
+++ b/xadmin/views/list.py
@@ -169,7 +169,6 @@ class ListAdminView(ModelAdminView):
 
     def make_result_list(self):
         # Get search parameters from the query string.
-        self.base_queryset = self.queryset()
         self.list_queryset = self.get_list_queryset()
         self.ordering_field_columns = self.get_ordering_field_columns()
         self.paginator = self.get_paginator()


### PR DESCRIPTION
还是重复查询的问题，我在 `adminx.py` 里重载了 `queryset()` ，发现在列表页，该函数执行了两次。经过跟踪是在 `ListAdminView.make_result_list()` 中：
```
 def make_result_list(self):
    # Get search parameters from the query string.
    self.base_queryset = self.queryset()
    self.list_queryset = self.get_list_queryset()
```
这两句都是查询会调用 `queryset()` 。经排查,变量 `base_queryset` 整个xadmin项目都没有用到，完全可以删除。