### PR TITLE
修复meta.get_all_field_names不存在问题

### DIFF
--- a/xadmin/plugins/inline.py
+++ b/xadmin/plugins/inline.py
@@ -227,10 +227,11 @@ class InlineModelAdmin(ModelFormAdminView):
                 form.readonly_fields = []
                 inst = form.save(commit=False)
                 if inst:
+                    meta_field_names = [field.name for field in inst._meta.get_fields()]
                     for readonly_field in readonly_fields:
                         value = None
                         label = None
-                        if readonly_field in inst._meta.get_all_field_names():
+                        if readonly_field in meta_field_names:
                             label = inst._meta.get_field(readonly_field).verbose_name
                             value = smart_text(getattr(inst, readonly_field))
                         elif inspect.ismethod(getattr(inst, readonly_field, None)):


### PR DESCRIPTION
在管理选项设置了 `readonly_field` 会触发这个问题，原因是 `get_all_field_names` 在 django1.10 版本后就都移除了。

![20180627141424](https://user-images.githubusercontent.com/7546325/41956415-26df530e-7a16-11e8-93c1-81d7245be874.png)

详情可见：[https://github.com/django/django/blob/ad8036d715d4447b95d485332511b4edb1a40c0e/docs/releases/1.10.txt#L1241](https://github.com/django/django/blob/ad8036d715d4447b95d485332511b4edb1a40c0e/docs/releases/1.10.txt#L1241)

其他被移除的函数尚未排查。我对这个项目的 `django2` 分支感兴趣，是否能加我做协作者，我想维护这个分支。

