### PR TITLE
[django2]左侧菜单内容过多时显示滚动条

### DIFF
--- a/xadmin/static/xadmin/css/xadmin.main.css
+++ b/xadmin/static/xadmin/css/xadmin.main.css
@@ -243,6 +243,9 @@ ul.nav-sitemenu li a {
 
 @media (min-width: 768px) {
   .panel-group.nav-sitemenu {
+    top: 65px;
+    bottom: 0;
+    overflow-y: auto;
     position: fixed;
     margin-left: -15px;
   }


### PR DESCRIPTION
因为左侧菜单栏是 `fixed` 布局，当内容超过高度是会被忽略。

![20180920114347](https://user-images.githubusercontent.com/7546325/45794901-714c2a00-bccb-11e8-9517-4df6dc7af0ca.png)

这个PR修复这个问题，效果图如下。

![20180920114809](https://user-images.githubusercontent.com/7546325/45794915-89bc4480-bccb-11e8-8421-9e2b570ede84.png)
