### PR TITLE
解决xadmin主题无效的问题

### DIFF
--- a/xadmin/plugins/themes.py
+++ b/xadmin/plugins/themes.py
@@ -1,6 +1,6 @@
 #coding:utf-8
 from __future__ import print_function
-import httplib2
+import requests
 from django.template import loader
 from django.core.cache import cache
 from django.utils import six
@@ -71,16 +71,13 @@ class ThemePlugin(BaseAdminPlugin):
             else:
                 ex_themes = []
                 try:
-                    h = httplib2.Http()
-                    resp, content = h.request("https://bootswatch.com/api/3.json", 'GET', '',
-                        headers={"Accept": "application/json", "User-Agent": self.request.META['HTTP_USER_AGENT']})
+                    headers = {"Accept": "application/json", "User-Agent": self.request.META['HTTP_USER_AGENT']}
+                    content = requests.get("https://bootswatch.com/api/3.json", headers=headers)
                     if six.PY3:
-                        content = content.decode()
-                    watch_themes = json.loads(content)['themes']
-                    ex_themes.extend([
-                        {'name': t['name'], 'description': t['description'],
-                            'css': t['cssMin'], 'thumbnail': t['thumbnail']}
-                        for t in watch_themes])
+                        content = content.text.decode()
+                    watch_themes = json.loads(content.text)['themes']
+                    ex_themes.extend([{'name': t['name'], 'description': t['description'], 'css': t['cssMin'],
+                                       'thumbnail': t['thumbnail']} for t in watch_themes])
                 except Exception as e:
                     print(e)
 


### PR DESCRIPTION
使用 httplib2 去访问 http://bootswatch.com/api/3.json
http 被替换为 https，由于安全机制访问就会报错，导致无法使用主题，改为使用 requests 即可。