### PR TITLE
adapt django3.0

### DIFF
--- a/demo_app/app/models.py
+++ b/demo_app/app/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import Group
 from django.conf import settings
-from django.utils.encoding import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 AUTH_USER_MODEL = getattr(settings, 'AUTH_USER_MODEL', 'auth.User')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ django>=2
 django-crispy-forms>=1.6.0
 django-import-export>=0.5.1
 django-reversion>=2.0.0
-django-formtools==2.1
+django-formtools==2.2
 future==0.15.2
 httplib2==0.9.2
 six==1.10.0

--- a/tests/xtests/site/apps.py
+++ b/tests/xtests/site/apps.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 #coding:utf-8
 import sys
-from django.utils import six
+import six
+
 if six.PY2 and sys.getdefaultencoding()=='ascii':
     import imp
     imp.reload(sys)

--- a/tests/xtests/view_base/apps.py
+++ b/tests/xtests/view_base/apps.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 #coding:utf-8
 import sys
-from django.utils import six
+import six
+
 if six.PY2 and sys.getdefaultencoding()=='ascii':
     import imp
     imp.reload(sys)

--- a/xadmin/filters.py
+++ b/xadmin/filters.py
@@ -202,7 +202,7 @@ class ChoicesFieldListFilter(ListFieldFilter):
 
     def choices(self):
         yield {
-            'selected': self.lookup_exact_val is '',
+            'selected': self.lookup_exact_val == '',
             'query_string': self.query_string({}, [self.lookup_exact_name]),
             'display': _('All')
         }
@@ -548,7 +548,7 @@ class AllValuesFieldListFilter(ListFieldFilter):
 
     def choices(self):
         yield {
-            'selected': (self.lookup_exact_val is '' and self.lookup_isnull_val is ''),
+            'selected': (self.lookup_exact_val == '' and self.lookup_isnull_val == ''),
             'query_string': self.query_string({}, [self.lookup_exact_name, self.lookup_isnull_name]),
             'display': _('All'),
         }

--- a/xadmin/filters.py
+++ b/xadmin/filters.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+import six
+
 from django.db import models
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.encoding import smart_text
@@ -6,12 +8,10 @@ from django.utils.translation import ugettext_lazy as _
 from django.utils import timezone
 from django.template.loader import get_template
 from django.template.context import Context
-from django.utils import six
 from django.utils.safestring import mark_safe
 from django.utils.html import escape, format_html
 from django.utils.text import Truncator
 from django.core.cache import cache, caches
-
 from xadmin.views.list import EMPTY_CHANGELIST_VALUE
 from xadmin.util import is_related_field, is_related_field2
 import datetime

--- a/xadmin/models.py
+++ b/xadmin/models.py
@@ -8,7 +8,8 @@ from django.utils.translation import ugettext_lazy as _, ugettext
 from django.urls.base import reverse
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models.base import ModelBase
-from django.utils.encoding import python_2_unicode_compatible, smart_text
+from django.utils.encoding import smart_text
+from six import python_2_unicode_compatible
 
 from django.db.models.signals import post_migrate
 from django.contrib.auth.models import Permission

--- a/xadmin/plugins/actions.py
+++ b/xadmin/plugins/actions.py
@@ -1,11 +1,12 @@
 from collections import OrderedDict
+import six
+
 from django import forms, VERSION as django_version
 from django.core.exceptions import PermissionDenied
 from django.db import router
 from django.http import HttpResponse, HttpResponseRedirect
 from django.template import loader
 from django.template.response import TemplateResponse
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _, ungettext

--- a/xadmin/plugins/export.py
+++ b/xadmin/plugins/export.py
@@ -2,10 +2,10 @@ import io
 import datetime
 import sys
 from future.utils import iteritems
+import six
 
 from django.http import HttpResponse
 from django.template import loader
-from django.utils import six
 from django.utils.encoding import force_text, smart_text
 from django.utils.html import escape
 from django.utils.translation import ugettext as _

--- a/xadmin/plugins/filters.py
+++ b/xadmin/plugins/filters.py
@@ -1,4 +1,6 @@
 import operator
+import six
+
 from future.utils import iteritems
 from xadmin import widgets
 from xadmin.plugins.utils import get_context_dict
@@ -10,7 +12,6 @@ from django.db.models.fields import FieldDoesNotExist
 from django.db.models.constants import LOOKUP_SEP
 # from django.db.models.sql.constants import QUERY_TERMS
 from django.template import loader
-from django.utils import six
 from django.utils.encoding import smart_str
 from django.utils.translation import ugettext as _
 

--- a/xadmin/plugins/inline.py
+++ b/xadmin/plugins/inline.py
@@ -1,5 +1,7 @@
 import copy
 import inspect
+import six
+
 from django import forms
 from django.forms.formsets import all_valid, DELETION_FIELD_NAME
 from django.forms.models import inlineformset_factory, BaseInlineFormSet, modelform_defines_fields
@@ -7,7 +9,6 @@ from django.contrib.contenttypes.forms import BaseGenericInlineFormSet, generic_
 from django.template import loader
 from django.template.loader import render_to_string
 from django.contrib.auth import get_permission_codename
-from django.utils import six
 from django.utils.encoding import smart_text
 from crispy_forms.utils import TEMPLATE_PACK
 

--- a/xadmin/plugins/quickfilter.py
+++ b/xadmin/plugins/quickfilter.py
@@ -4,7 +4,8 @@ Created on Mar 26, 2014
 @author: LAB_ADM
 '''
 from future.utils import iteritems
-from django.utils import six
+import six
+
 from django.utils.translation import ugettext_lazy as _
 from xadmin.filters import manager, MultiSelectFieldListFilter
 from xadmin.plugins.filters import *

--- a/xadmin/plugins/relate.py
+++ b/xadmin/plugins/relate.py
@@ -1,9 +1,9 @@
 # coding=UTF-8
 from itertools import chain
+import six
 
 from django.urls.base import reverse
 from django.db.models.options import PROXY_PARENTS
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.encoding import smart_str
 from django.utils.safestring import mark_safe

--- a/xadmin/plugins/themes.py
+++ b/xadmin/plugins/themes.py
@@ -1,9 +1,10 @@
 # coding:utf-8
 from __future__ import print_function
 import httplib2
+import six
+
 from django.template import loader
 from django.core.cache import cache
-from django.utils import six
 from django.utils.translation import ugettext as _
 from xadmin.sites import site
 from xadmin.models import UserSettings

--- a/xadmin/plugins/wizard.py
+++ b/xadmin/plugins/wizard.py
@@ -1,4 +1,6 @@
 import re
+import six
+
 from collections import OrderedDict
 from django import forms
 from django.db import models
@@ -13,7 +15,6 @@ except:
     from django.contrib.formtools.wizard.forms import ManagementForm
     from django.contrib.formtools.wizard.views import StepsHelper
 
-from django.utils import six
 from django.utils.encoding import smart_text
 from django.utils.module_loading import import_string
 from django.forms import ValidationError

--- a/xadmin/plugins/xversion.py
+++ b/xadmin/plugins/xversion.py
@@ -1,3 +1,5 @@
+import six
+
 from crispy_forms.utils import TEMPLATE_PACK
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -8,7 +10,6 @@ from django.forms.models import model_to_dict
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
-from django.utils import six
 from django.utils.encoding import force_text, smart_text
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst

--- a/xadmin/sites.py
+++ b/xadmin/sites.py
@@ -1,10 +1,11 @@
 import sys
+import six
+
 from functools import update_wrapper
 from future.utils import iteritems
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.base import ModelBase
-from django.utils import six
 from django.views.decorators.cache import never_cache
 from django.template.engine import Engine
 import inspect

--- a/xadmin/templatetags/xadmin_tags.py
+++ b/xadmin/templatetags/xadmin_tags.py
@@ -1,6 +1,7 @@
+import six
+
 from django import template
 from django.template import Library
-from django.utils import six
 from django.utils.safestring import mark_safe
 from django.utils.html import escape
 

--- a/xadmin/util.py
+++ b/xadmin/util.py
@@ -1,11 +1,13 @@
 from __future__ import absolute_import
+import six
+
 import django
 from django.db import models
 from django.db.models.sql.query import LOOKUP_SEP
 from django.db.models.deletion import Collector
 from django.db.models.fields.related import ForeignObjectRel
 from django.forms.forms import pretty_name
-from django.utils import formats, six
+from django.utils import formats
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
@@ -20,10 +22,7 @@ from django import VERSION as version
 import datetime
 import decimal
 
-if 'django.contrib.staticfiles' in settings.INSTALLED_APPS:
-    from django.contrib.staticfiles.templatetags.staticfiles import static
-else:
-    from django.templatetags.static import static
+from django.templatetags.static import static
 
 try:
     import json

--- a/xadmin/views/base.py
+++ b/xadmin/views/base.py
@@ -2,6 +2,7 @@ import copy
 import functools
 import datetime
 import decimal
+import six
 from functools import update_wrapper
 from inspect import getfullargspec
 
@@ -16,7 +17,6 @@ from django.urls.base import reverse
 from django.http import HttpResponse
 from django.template import Context, Template
 from django.template.response import TemplateResponse
-from django.utils import six
 from django.utils.decorators import method_decorator, classonlymethod
 from django.utils.encoding import force_text, smart_text, smart_str
 from django.utils.functional import Promise

--- a/xadmin/views/delete.py
+++ b/xadmin/views/delete.py
@@ -1,9 +1,10 @@
+import six
+
 from django.core.exceptions import PermissionDenied
 from django.db import transaction, router
 from django.http import Http404, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django import VERSION as django_version
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.translation import ugettext as _

--- a/xadmin/views/detail.py
+++ b/xadmin/views/detail.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import copy
+import six
 
 from crispy_forms.utils import TEMPLATE_PACK
 from django import forms
@@ -10,7 +11,6 @@ from django.forms.models import modelform_factory
 from django.http import Http404
 from django.template import loader
 from django.template.response import TemplateResponse
-from django.utils import six
 from django.utils.encoding import force_text, smart_text
 from django.utils.html import escape
 from django.utils.safestring import mark_safe

--- a/xadmin/views/edit.py
+++ b/xadmin/views/edit.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import copy
+import six
 
 from crispy_forms.utils import TEMPLATE_PACK
 from django import forms
@@ -9,7 +10,6 @@ from django.db import models, transaction
 from django.forms.models import modelform_factory, modelform_defines_fields
 from django.http import Http404, HttpResponseRedirect
 from django.template.response import TemplateResponse
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.utils.text import capfirst, get_text_list

--- a/xadmin/views/form.py
+++ b/xadmin/views/form.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import copy
+import six
 
 from django import forms
 from django.contrib.contenttypes.models import ContentType
@@ -8,7 +9,6 @@ from django.db import models, transaction
 from django.forms.models import modelform_factory
 from django.http import Http404, HttpResponseRedirect
 from django.template.response import TemplateResponse
-from django.utils import six
 from django.utils.encoding import force_text
 from django.utils.html import escape
 from django.template import loader

--- a/xadmin/views/list.py
+++ b/xadmin/views/list.py
@@ -1,4 +1,6 @@
 from __future__ import absolute_import
+import six
+
 from collections import OrderedDict
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.core.paginator import InvalidPage, Paginator
@@ -6,7 +8,6 @@ from django.urls.base import NoReverseMatch
 from django.db import models
 from django.http import HttpResponseRedirect
 from django.template.response import SimpleTemplateResponse, TemplateResponse
-from django.utils import six
 from django.utils.encoding import force_text, smart_text
 from django.utils.html import escape, conditional_escape
 from django.utils.safestring import mark_safe


### PR DESCRIPTION
适配Django3.0版本，测试通过
Django中six包已经移除，使用独立的第三方包
requirements.txt中django-formtools==2.2需要升级到2.2版本，2.1版本会报错
from django.utils import six ==> import six

from django.core.urlresolvers import NoReverseMatch, reverse ==> from django.urls import NoReverseMatch, reverse
...